### PR TITLE
docs: add changelog and contributing guidelines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+## Unreleased
+- Added documentation update prompt under `prompts/projects/`.
+- Introduced `AGENTS.md` guidelines and `LICENSE`.
+- Established initial project structure and README.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,12 @@
+# Contributing
+
+Thank you for contributing to **jonv11-prompts-library**. To keep the library consistent:
+
+- Use English unless a prompt specifies another language.
+- Name files using `prompt-<keywords>.md`.
+- Place prompts in the appropriate folder under `prompts/` (`coding/`, `data/`, `agents/`, `projects/`, `chat/`, `other/`).
+- Keep prompts clear, agent-agnostic, and reusable.
+- Avoid duplication across categories.
+- Update documentation when adding new prompts or folders.
+- All contributions are released under the CC-BY 4.0 license.
+- Refer to [AGENTS.md](AGENTS.md) for project roles and conventions.

--- a/README.md
+++ b/README.md
@@ -7,22 +7,24 @@ The goal is to keep prompts organized, portable, and ready to use across coding,
 
 ```
 jonv11-prompts-library/
+├── AGENTS.md
+├── CHANGELOG.md
+├── CONTRIBUTING.md
+├── LICENSE
 ├── README.md
-├── prompts/
-│   ├── coding/
-│   ├── data/
-│   ├── agents/
-│   ├── projects/
-│   ├── chat/
-│   └── other/
+└── prompts/
+    └── projects/
+        └── prompt-update-docs.md
 ```
 
-- **coding/**: prompts for code generation, debugging, optimization.  
-- **data/**: prompts for analysis, visualization, entity resolution, statistics.  
-- **agents/**: prompts defining AI agent roles, behaviors, workflows.  
-- **projects/**: prompts for project initiation, planning, specs, docs.  
-- **chat/**: prompts for conversational use, fact-checking, Q&A.  
+The library organizes prompts by category. Currently only the `projects/` folder is populated, but additional folders can be added as the library grows:
+
+- **coding/**: prompts for code generation, debugging, optimization.
+- **data/**: prompts for analysis, visualization, entity resolution, statistics.
+- **agents/**: prompts defining AI agent roles, behaviors, workflows.
+- **chat/**: prompts for conversational use, fact-checking, Q&A.
 - **other/**: prompts that don’t fit the main categories.
+- **projects/**: prompts for project initiation, planning, specs, docs.
 
 Each prompt is a standalone `.md` file with:
 - **Descriptive filename** (e.g., `prompt-code-review.md`).  
@@ -37,11 +39,13 @@ Each prompt is a standalone `.md` file with:
 
 ## Contribution
 
-- Keep prompts short, clear, and generic enough to be reused.  
-- Use English as default language unless the prompt specifies otherwise.  
-- Follow the naming pattern: `prompt-<keywords>.md`.  
-- Place in the correct category subfolder.  
+- Keep prompts short, clear, and generic enough to be reused.
+- Use English as default language unless the prompt specifies otherwise.
+- Follow the naming pattern: `prompt-<keywords>.md`.
+- Place in the correct category subfolder.
 - Add documentation when needed.
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for full guidelines.
 
 ## License
 


### PR DESCRIPTION
## Summary
- document current repository structure and link to contributing guide
- add CONTRIBUTING guidelines for prompt naming and categories
- start a CHANGELOG to track additions

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b6457532f88324a669443dfba204c0