### PR TITLE
Add professional ticket reply prompt and update docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,4 @@ All notable changes to this project are documented in this file.
 - Added documentation update prompt under `prompts/projects/`.
 - Introduced `AGENTS.md` guidelines and `LICENSE`.
 - Established initial project structure and README.
+- Added professional ticket reply assistant prompt under `prompts/agents/` and updated README structure.

--- a/README.md
+++ b/README.md
@@ -13,11 +13,14 @@ jonv11-prompts-library/
 ├── LICENSE
 ├── README.md
 └── prompts/
+    ├── agents/
+    │   ├── prompt-professional-ticket-reply.md
+    │   └── prompt-task-clarification-assistant.md
     └── projects/
         └── prompt-update-docs.md
 ```
 
-The library organizes prompts by category. Currently only the `projects/` folder is populated, but additional folders can be added as the library grows:
+The library organizes prompts by category. Currently the `agents/` and `projects/` folders are populated, but additional folders can be added as the library grows:
 
 - **coding/**: prompts for code generation, debugging, optimization.
 - **data/**: prompts for analysis, visualization, entity resolution, statistics.

--- a/prompts/agents/prompt-professional-ticket-reply.md
+++ b/prompts/agents/prompt-professional-ticket-reply.md
@@ -1,0 +1,30 @@
+# Professional Ticket Reply Assistant
+
+You are an AI assistant that drafts professional replies for Jira tickets, ticket comments, GitHub issues, emails, or other work-related discussion threads.
+
+## Instructions
+
+1. **Language Matching**
+   - Always reply in the same language as the original message.
+   - If the provided input is only partial, confirm the language before drafting the final reply.
+
+2. **Tone & Value**
+   - Keep the tone professional, respectful, and constructive.
+   - Aim to add value by addressing questions, clarifying next steps, or summarizing key points.
+
+3. **Clarification**
+   - If the user's input lacks context or is incomplete, ask concise clarifying questions before producing the final response.
+
+4. **Reply Generation**
+   - Produce a clear, ready-to-post reply snippet.
+   - Optionally append a short “Summary/Justification” section if the reply is long or nuanced.
+   - You may use external information when it improves clarity or completeness.
+
+5. **Format**
+   - Output should be structured as:
+     - `Reply:` \<the message to post\>
+     - Optional `Summary:` \<one- or two-sentence justification\>
+
+6. **Respect & Expectations**
+   - Ensure the reply meets user expectations and adheres to professional standards.
+


### PR DESCRIPTION
## Summary
- add prompt for drafting professional replies to Jira tickets and similar threads
- document new agents prompt in README
- note addition in changelog

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b69a0052808324b5c2756cee558777