### PR TITLE
Add concept functional note prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to this project are documented in this file.
 
 ## Unreleased
+- Added concept functional note assistant prompt under `prompts/projects/`.
+- Refined validation checklist for concept functional note assistant prompt (note provided as downloadable Markdown with descriptive filename).
 - Added documentation update prompt under `prompts/projects/`.
 - Introduced `AGENTS.md` guidelines and `LICENSE`.
 - Established initial project structure and README.

--- a/README.md
+++ b/README.md
@@ -14,9 +14,12 @@ jonv11-prompts-library/
 ├── README.md
 └── prompts/
     ├── agents/
+    │   ├── prompt-meta-prompt-generator.md
     │   ├── prompt-professional-ticket-reply.md
     │   └── prompt-task-clarification-assistant.md
     └── projects/
+        ├── prompt-concept-functional-note.md
+        ├── prompt-repo-bootstrap.md
         └── prompt-update-docs.md
 ```
 

--- a/prompts/projects/prompt-concept-functional-note.md
+++ b/prompts/projects/prompt-concept-functional-note.md
@@ -1,0 +1,52 @@
+<!-- Licensed under CC-BY 4.0. -->
+
+# Concept Functional Note Assistant
+
+## Purpose
+Guide a user through defining a concept and produce a functional note with a complete, professional description.
+
+## Inputs
+- Concept name or brief description
+- Audience or domain (optional)
+- Objectives or rationale
+- Key components or features
+- Examples or use cases
+- Dependencies or references
+- Additional constraints or notes
+
+## Steps
+1. Ask the user for the concept name and a short description.
+2. Iteratively gather details:
+   - Purpose or problem solved.
+   - Audience and context.
+   - Key features, components, or requirements.
+   - Examples, use cases, or references.
+   - Dependencies, constraints, or open questions.
+3. Present a summary checklist of collected details and ask for confirmation or edits.
+4. After confirmation, generate a functional note document with clear sections.
+5. Provide the final note to the user.
+
+## Output
+- A polished functional note describing the concept, structured with sections such as **Overview**, **Details**, **Use Cases**, **References**, and **Open Questions**.
+
+## Acceptance Criteria
+- Interactive clarification covers all relevant details before generating the note.
+- Final document is professional, comprehensive, and organized.
+- Uses consistent terminology and follows user-provided constraints.
+- Output is in Markdown format ready for further editing or sharing.
+
+## Metadata
+- tags: documentation, concept, functional-note
+- target: ChatGPT, GitHub Copilot/Codex
+- language: English
+
+## Notes
+- Customize section headings if the user prefers another structure.
+- Keep questions concise and focused on missing information.
+
+## Validation Checklist
+- [ ] Asks for concept name and short description.
+- [ ] Collects purpose, audience, key features, use cases, dependencies, and constraints.
+- [ ] Summarizes collected details for confirmation before finalizing.
+- [ ] Produces a Markdown note with sections such as Overview, Details, Use Cases, References, and Open Questions.
+- [ ] Offers the final note as a downloadable Markdown file named descriptively (e.g., `best-bread-recipe.md`).


### PR DESCRIPTION
## Summary
- add Concept Functional Note Assistant prompt for documenting concepts through interactive clarification
- require the final note to be downloadable Markdown with descriptive filename
- update changelog

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b6df24f8b48324a86df48c5151d41d