### PR TITLE
Add Codex prompt design guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ jonv11-prompts-library/
 ├── CONTRIBUTING.md
 ├── LICENSE
 ├── README.md
+├── docs/
+│   └── codex-prompt-guide.md
 └── prompts/
     ├── agents/
     │   ├── prompt-meta-prompt-generator.md
@@ -23,7 +25,7 @@ jonv11-prompts-library/
         └── prompt-update-docs.md
 ```
 
-The library organizes prompts by category. Currently the `agents/` and `projects/` folders are populated, but additional folders can be added as the library grows:
+Additional documentation lives under `docs/`. The library organizes prompts by category. Currently the `agents/` and `projects/` folders are populated, but additional folders can be added as the library grows:
 
 - **coding/**: prompts for code generation, debugging, optimization.
 - **data/**: prompts for analysis, visualization, entity resolution, statistics.

--- a/docs/codex-prompt-guide.md
+++ b/docs/codex-prompt-guide.md
@@ -1,0 +1,45 @@
+# Creating Effective Prompts for OpenAI Codex
+
+This guide summarizes best practices for working with OpenAI Codex to maintain repositories and design prompts. Codex acts as a cloud-based coding agent that can read and modify your repository, run tests, and propose pull requests.
+
+## Crafting Prompts
+
+- **Be clear and specific**: Describe the exact change or question. Reference files or functions directly and include code snippets when helpful.
+- **Provide context**: Mention related modules or existing issues so Codex focuses on the right areas.
+- **Use an instructional tone**: Frame prompts as direct tasks or commands with acceptance criteria.
+- **State goals**: Explain success conditions such as performance targets or test expectations.
+- **Keep tasks focused**: Break large requests into smaller sequential steps.
+- **Iterate**: Review Codex's output, then refine prompts or request follow‑up changes.
+- **Leverage Q&A mode**: Ask Codex about codebase details before assigning modifications.
+
+## Preparing the Repository
+
+- **AGENTS.md**: Document project structure, build/test commands, style guides, and pull request conventions.
+- **README.md**: Provide high‑level project overview, setup instructions, and usage examples.
+- **Build and dependency files**: Ensure configuration files like `package.json`, `.csproj`, or `build.sbt` are present and accurate.
+- **Tests**: Maintain a comprehensive test suite and document how to run it.
+- **Linting and formatting**: Include configuration files and pre‑commit hooks for style enforcement.
+- **Environment setup**: Supply example configs or Docker files to replicate the development environment.
+
+## Delegating Tasks to Codex
+
+Codex can automate many maintenance activities:
+
+1. **Update dependencies** and adjust code for compatibility, running tests afterward.
+2. **Fix bugs** by describing symptoms and expected behavior; request accompanying tests.
+3. **Implement features** by outlining modules, functions, and integration points.
+4. **Refactor code** with goals like reducing duplication while preserving behavior.
+5. **Revise documentation** such as README updates or code comments.
+
+## Limitations and Best Practices
+
+- **Review outputs** as you would a junior developer's work and run tests independently.
+- **Provide sufficient context** for very large repositories or multiple services.
+- **Plan prompts carefully** since mid‑task corrections are not possible.
+- **Monitor task duration and usage limits**; break up long‑running jobs.
+- **Consider privacy and security** when running Codex on sensitive code or with internet access.
+- **Rely on CI and test suites** to validate changes before merging.
+- **Refine AGENTS.md and docs** to align Codex with project standards.
+
+By supplying clear instructions, maintaining thorough documentation, and using a robust test suite, you can delegate routine repository tasks to Codex with confidence.
+


### PR DESCRIPTION
## Summary
- add documentation on crafting effective prompts for OpenAI Codex
- update repository structure in README to reference new docs directory

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b764e996208324a72fad986965213a