### PR TITLE
Add prompt crafting guides for common LLM workflows

### DIFF
--- a/docs/chat-prompt-guide.md
+++ b/docs/chat-prompt-guide.md
@@ -1,0 +1,19 @@
+# Simple Chat Prompt Guide
+
+This guide covers prompt crafting for chat interfaces like ChatGPT or Copilot where only the prompt text is available.
+
+## Strategies
+
+- **Establish a role**: Set the assistant's persona or expertise at the start.
+- **Deliver necessary background**: Include all context the model needs since no external files are loaded.
+- **Ask direct questions or tasks**: Keep requests focused and unambiguous.
+- **Specify format and tone**: Indicate if the response should be concise, formal, or in a specific structure.
+- **Encourage step-by-step reasoning**: Request explanations or intermediate steps for clarity.
+- **Use delimiters for code or data**: Fence code blocks with backticks to preserve formatting.
+- **Set boundaries**: Mention length limits, forbidden topics, or required citations.
+
+## Managing Dialog
+
+- **Reference prior messages** when continuing a conversation to maintain context.
+- **Summarize progress** if the thread becomes long so the assistant stays on track.
+- **Invite clarifying questions** when the task may be misunderstood.

--- a/docs/codex-prompt-guide.md
+++ b/docs/codex-prompt-guide.md
@@ -2,6 +2,17 @@
 
 This guide summarizes best practices for working with OpenAI Codex to maintain repositories and design prompts. Codex acts as a cloud-based coding agent that can read and modify your repository, run tests, and propose pull requests.
 
+## Key Context Files
+
+Codex inspects several files to understand your project before acting:
+
+- **AGENTS.md** – rules for agent behavior, build commands, and style expectations.
+- **README.md** – overview, setup notes, and usage examples that frame tasks.
+- **Build and dependency configs** (e.g., `package.json`, `.csproj`) – reveal languages, scripts, and required tools.
+- **Tests** – show expected behavior and regression safeguards.
+- **Linting and formatting configs** – enforce style and quality gates.
+- **Environment examples** (like Docker files) – document how to reproduce the setup.
+
 ## Crafting Prompts
 
 - **Be clear and specific**: Describe the exact change or question. Reference files or functions directly and include code snippets when helpful.
@@ -14,12 +25,11 @@ This guide summarizes best practices for working with OpenAI Codex to maintain r
 
 ## Preparing the Repository
 
-- **AGENTS.md**: Document project structure, build/test commands, style guides, and pull request conventions.
-- **README.md**: Provide high‑level project overview, setup instructions, and usage examples.
-- **Build and dependency files**: Ensure configuration files like `package.json`, `.csproj`, or `build.sbt` are present and accurate.
-- **Tests**: Maintain a comprehensive test suite and document how to run it.
-- **Linting and formatting**: Include configuration files and pre‑commit hooks for style enforcement.
-- **Environment setup**: Supply example configs or Docker files to replicate the development environment.
+- Keep **AGENTS.md** and **README.md** current so Codex receives accurate instructions.
+- Ensure build and dependency files reflect supported languages and scripts.
+- Maintain a comprehensive test suite and document how to run it.
+- Include linting and formatting configs plus pre‑commit hooks to enforce style.
+- Provide environment examples (Docker files, `.env` templates) to reproduce the setup.
 
 ## Delegating Tasks to Codex
 

--- a/docs/generic-prompt-guide.md
+++ b/docs/generic-prompt-guide.md
@@ -1,0 +1,19 @@
+# Generic Prompt Crafting Guide
+
+This guide outlines universal techniques for designing effective prompts for large language models and AI assistants.
+
+## Core Principles
+
+- **State the goal**: Describe the desired outcome and target audience.
+- **Provide context**: Supply background, assumptions, and any relevant data or prior steps.
+- **Structure the task**: Use ordered steps or bullet points to reduce ambiguity.
+- **Define output format**: Specify whether the response should be code, JSON, a table, or prose.
+- **Show examples**: Offer input/output pairs to illustrate expectations.
+- **Set constraints**: Note length limits, style preferences, or forbidden actions.
+- **Invite reasoning**: Ask the model to explain its steps or verify results.
+
+## Iterative Refinement
+
+- **Review and adjust**: Examine the output and refine the prompt for clarity or additional constraints.
+- **Break down complex tasks**: Split large objectives into smaller prompts and build on prior results.
+- **Encourage questions**: Allow the assistant to request clarification when requirements are unclear.

--- a/docs/githubcopilot-prompt-guide.md
+++ b/docs/githubcopilot-prompt-guide.md
@@ -1,0 +1,28 @@
+# Creating Effective Prompts for GitHub Copilot
+
+This guide explains how to steer GitHub Copilot within your editor to produce useful code suggestions.
+
+## Key Context Files
+
+Copilot draws context from your workspace to craft completions:
+
+- **Open file around the cursor** – primary source for style and intent.
+- **Neighboring files and imports** – help Copilot infer APIs and patterns.
+- **README.md and other docs** – provide project goals and usage examples.
+- **Build and dependency configs** (e.g., `package.json`, `pyproject.toml`) – reveal frameworks, scripts, and versions.
+- **Tests and example files** – show expected behavior and edge cases.
+- **Lint and formatting configs** – influence stylistic choices like tabs or semicolons.
+
+## Crafting Prompts
+
+- **Write descriptive comments** before functions or blocks to explain desired behavior.
+- **Name functions and variables clearly** to signal intent.
+- **Provide small scaffolds** such as TODOs, signature stubs, or sample inputs.
+- **Specify output structure** in comments or docstrings when necessary.
+- **Iterate** by accepting, editing, or rejecting suggestions to guide future completions.
+
+## Best Practices
+
+- **Keep context files accurate** so Copilot bases suggestions on the latest code.
+- **Add unit tests** to reinforce expected behavior and guide completions.
+- **Review generated code** for security, performance, and licensing before committing.

--- a/docs/project-prompt-guide.md
+++ b/docs/project-prompt-guide.md
@@ -1,0 +1,24 @@
+# Project Prompt Guide
+
+Use ChatGPT's **Projects** feature to share persistent instructions and files across conversations. A project acts as a workspace where uploaded code, docs, and notes are available to every chat started within the project.
+
+## Setup
+
+- **Upload context files**: Add key docs like `README.md`, `AGENTS.md`, and relevant source files so the assistant can reference them.
+- **Project instructions**: Set high-level guidelines—style rules, build steps, or goals—that apply to all chats in the project.
+- **Organize files**: Maintain a clear structure so paths are predictable.
+
+## Prompting Strategies
+
+- **Mention exact paths**: Refer to specific files or directories when making requests.
+- **Describe desired changes**: Provide goals, acceptance criteria, and edge cases.
+- **Quote relevant snippets**: Include line numbers or code blocks to focus edits.
+- **Request commands**: Ask the assistant to run build or test commands after changes.
+- **Iterate**: Break large tasks into smaller prompts and review results incrementally.
+- **Update context**: Refresh project instructions or files when dependencies change.
+
+## Collaboration Tips
+
+- **Keep project files current** so future chats use accurate context.
+- **Use version control**: Commit small, atomic changes for easy review and rollback.
+- **Verify outputs**: Run tests and inspect diffs before merging.


### PR DESCRIPTION
## Summary
- add generic prompt crafting guide with core principles
- document strategies for simple chats
- provide project and GitHub Copilot guides and expand Codex guide with context files
- clarify ChatGPT Project guide for persistent shared context

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7686d3e2883249f1c6f717cfc3bb4