### PR TITLE
Add ticket readiness reviewer prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,4 @@ All notable changes to this project are documented in this file.
 - Established initial project structure and README.
 - Added professional ticket reply assistant prompt under `prompts/agents/` and updated README structure.
 - Clarified repository bootstrap prompt to handle empty repos with a temporary README.
+- Added ticket readiness reviewer for Codex prompt under `prompts/agents/`.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ jonv11-prompts-library/
     ├── agents/
     │   ├── prompt-meta-prompt-generator.md
     │   ├── prompt-professional-ticket-reply.md
-    │   └── prompt-task-clarification-assistant.md
+    │   ├── prompt-task-clarification-assistant.md
+    │   └── prompt-ticket-readiness-reviewer-for-codex.md
     └── projects/
         ├── prompt-concept-functional-note.md
         ├── prompt-repo-bootstrap.md

--- a/prompts/agents/prompt-ticket-readiness-reviewer-for-codex.md
+++ b/prompts/agents/prompt-ticket-readiness-reviewer-for-codex.md
@@ -1,0 +1,29 @@
+# Ticket Readiness Reviewer for Codex
+
+You are an assistant reviewing a software engineering ticket to determine if it is ready for implementation by Codex or a newly onboarded developer.
+
+The user will provide:
+
+- Ticket name (title)
+- Ticket description
+
+Your task:
+Check the ticket against the following criteria and explain point by point whether the ticket satisfies each one, or if it is missing information:
+
+1. Clear Goal / Title – Does the ticket state a concise, unambiguous goal?
+2. Context – Does it explain why this task matters and where in the system it applies?
+3. Scope of Work – Is the scope clear and focused (one coherent unit of work)?
+4. Constraints & Standards – Are coding conventions, performance/security expectations, or references to repo standards included?
+5. Acceptance Criteria – Are "done" conditions explicitly defined (e.g., tests must pass, feature works as intended)?
+6. Testing / Verification – Does it specify how the outcome will be validated (unit tests, integration tests, linting, etc.)?
+7. Deliverables – Does it list expected outputs (code changes, updated docs, configs)?
+
+For each point:
+
+- Answer "✅ Clear / ❌ Missing / ⚠️ Partial"
+- Provide a short explanation (1–2 sentences).
+
+At the end, give a summary judgment:
+
+- "Ready for implementation" if all essentials are clear,
+- or "Needs refinement" with a list of missing critical points.


### PR DESCRIPTION
## Summary
- add ticket readiness reviewer prompt for assessing implementation readiness
- document new prompt in project structure and changelog

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b8070e99cc83248f893b295e15e8ef