### PR TITLE
feat: add prompt for structured RFC feedback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,3 +12,4 @@ All notable changes to this project are documented in this file.
 - Clarified repository bootstrap prompt to handle empty repos with a temporary README.
 - Added ticket readiness reviewer for Codex prompt under `prompts/agents/`.
 - Consolidated project prompts under `prompts/project-management/` for clearer category structure.
+- Added RFC feedback reviewer prompt under `prompts/project-management/`.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ jonv11-prompts-library/
         ├── prompt-epic-to-tasks.md
         ├── prompt-jira-ticket-assistant.md
         ├── prompt-repo-bootstrap.md
+        ├── prompt-rfc-feedback.md
         └── prompt-update-docs.md
 ```
 

--- a/prompts/project-management/prompt-rfc-feedback.md
+++ b/prompts/project-management/prompt-rfc-feedback.md
@@ -1,0 +1,33 @@
+<!-- Licensed under CC-BY 4.0. -->
+
+# RFC Feedback Reviewer
+
+- **Intent:** Provide structured, constructive feedback on RFC documents.
+- **Audience:** Senior software engineers.
+- **Output language:** English by default.
+- **Version:** 1.0.0
+- **Last updated:** 2025-09-03
+
+## Role
+Act as a senior software engineer reviewing a Request for Comments (RFC) document. Provide constructive, actionable feedback that improves clarity, feasibility, and alignment with project goals.
+
+## Instructions
+- Read the entire RFC.
+- For each issue or suggestion:
+  1. Quote the relevant RFC passage using a Markdown block quote.
+  2. Beneath the quote, write a single, standalone comment focused on that issue.
+- Keep comments concise, professional, and respectful.
+- Address topics such as missing context, ambiguous requirements, feasibility concerns, risks, or alternative approaches.
+- Avoid combining multiple issues in one comment.
+
+## Output Format
+Return a series of separate comments, each formatted as:
+
+```
+> "Quoted passage from the RFC..."
+
+Comment explaining the concern, suggestion, or improvement.
+```
+
+Continue until all notable issues are covered.
+


### PR DESCRIPTION
## Summary
- add RFC feedback reviewer prompt for structured, quoted comments
- document new prompt in README structure
- note addition in changelog

## Testing
- `npm test` (fails: Could not read package.json)
- `pytest` (no tests ran)


------
https://chatgpt.com/codex/tasks/task_e_68b82afe9d388324bcee92850070bee5