### PR TITLE
feat: add maintenance task prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project are documented in this file.
 
 ## Unreleased
+- Added maintenance task prompts under `prompts/tasks/` and updated README.
 - Added concept functional note assistant prompt under `prompts/project-management/`.
 - Refined validation checklist for concept functional note assistant prompt (note provided as downloadable Markdown with descriptive filename).
 - Added documentation update prompt under `prompts/project-management/`.

--- a/README.md
+++ b/README.md
@@ -20,16 +20,22 @@ jonv11-prompts-library/
     │   ├── prompt-professional-ticket-reply.md
     │   ├── prompt-task-clarification-assistant.md
     │   └── prompt-ticket-readiness-reviewer-for-codex.md
-    └── project-management/
-        ├── prompt-concept-functional-note.md
-        ├── prompt-epic-to-tasks.md
-        ├── prompt-jira-ticket-assistant.md
-        ├── prompt-repo-bootstrap.md
-        ├── prompt-rfc-feedback.md
-        └── prompt-update-docs.md
+    ├── project-management/
+    │   ├── prompt-concept-functional-note.md
+    │   ├── prompt-epic-to-tasks.md
+    │   ├── prompt-jira-ticket-assistant.md
+    │   ├── prompt-repo-bootstrap.md
+    │   ├── prompt-rfc-feedback.md
+    │   └── prompt-update-docs.md
+    └── tasks/
+        ├── prompt-tasks-weekly-maintenance.md
+        ├── prompt-tasks-monthly-maintenance.md
+        ├── prompt-tasks-release-checklist.md
+        ├── prompt-tasks-occasional-review.md
+        └── prompt-tasks-comprehensive-maintenance.md
 ```
 
-Additional documentation lives under `docs/`. The library organizes prompts by category. Currently the `agents/` and `project-management/` folders are populated, but additional folders can be added as the library grows:
+Additional documentation lives under `docs/`. The library organizes prompts by category. Currently the `agents/`, `project-management/`, and `tasks/` folders are populated, but additional folders can be added as the library grows:
 
 - **coding/**: prompts for code generation, debugging, optimization.
 - **data/**: prompts for analysis, visualization, entity resolution, statistics.
@@ -37,6 +43,7 @@ Additional documentation lives under `docs/`. The library organizes prompts by c
 - **chat/**: prompts for conversational use, fact-checking, Q&A.
 - **other/**: prompts that don’t fit the main categories.
 - **project-management/**: prompts for project initiation, planning, ticketing, and documentation (e.g., `prompt-jira-ticket-assistant.md`).
+- **tasks/**: prompts for recurring maintenance, release prep, and audit checklists.
 
 Each prompt is a standalone `.md` file with:
 - **Descriptive filename** (e.g., `prompt-code-review.md`).  

--- a/prompts/tasks/prompt-tasks-comprehensive-maintenance.md
+++ b/prompts/tasks/prompt-tasks-comprehensive-maintenance.md
@@ -1,0 +1,40 @@
+# Comprehensive Maintenance Checklist
+
+Use this prompt when performing a full maintenance sweep. It combines weekly, monthly, release, and occasional tasks.
+
+## Weekly Tasks
+- Review dependency update PRs (Renovate/Dependabot) and pin versions.
+- Run SCA/SAST and secret scans; triage and address findings.
+- Lint and format the entire repository; ensure `.editorconfig` and `.gitattributes` are respected.
+- Assess test health: flaky tests, coverage trends, and run a small mutation-testing sample.
+- Check CI health: job durations, cache hit rate, flaky jobs, missing matrix targets.
+- Triage `TODO`/`FIXME` tags and suppression comments.
+- Sweep documentation for freshness (`README`, `CONTRIBUTING`, setup steps); test new-machine install.
+- Link and spell check all docs; verify code snippets compile.
+
+## Monthly Tasks
+- Architecture review; update ADRs and diagrams; examine the dependency graph for tangles.
+- Remove dead code and unused modules; plan deprecations; audit public API surface.
+- Capture performance baselines and detect regressions on key paths.
+- Perform a supply chain audit: build an SBOM, check license compliance, update third-party notices.
+- Verify lockfiles and reproducible builds; ensure deterministic outputs.
+- Check configuration and infrastructure drift across environments; maintain parity of flags and defaults.
+- Review access: tokens, keys, secret rotation, least-privilege policies.
+- Confirm ownership accuracy: `CODEOWNERS`, runbooks, on-call docs.
+- Ensure cross-repo consistency: PR/issue templates, commit message rules, branching model.
+
+## Release Tasks
+- Verify versioning and `CHANGELOG` updates; confirm semantic version bump.
+- Provide migration notes and deprecation warnings where needed.
+- Execute a clean-room build and run E2E and smoke tests on all target OS/architectures.
+- Perform packaging checks: signing, attach SBOM, ensure license headers.
+- Finalize release notes; regenerate and publish the docs site.
+
+## Occasional Tasks
+- Update threat model and data-flow diagrams.
+- Run backup and restore drills if data is involved.
+- Expand benchmark suite and test datasets.
+- Check privacy and retention policy compliance.
+
+## Automation
+- Leverage tools like Renovate/Dependabot, CodeQL or equivalent, secret scanners, link and spell checkers, doc snippet compilers, flaky-test detectors, coverage gating, and release CI with changelog generation wherever possible.

--- a/prompts/tasks/prompt-tasks-monthly-maintenance.md
+++ b/prompts/tasks/prompt-tasks-monthly-maintenance.md
@@ -1,0 +1,13 @@
+# Monthly Maintenance Checklist
+
+First complete the **Weekly Maintenance Checklist**. In addition, perform these monthly or quarterly tasks:
+
+- Architecture review; update ADRs and diagrams; examine the dependency graph for tangles.
+- Remove dead code and unused modules; plan deprecations; audit public API surface.
+- Capture performance baselines and detect regressions on key paths.
+- Perform a supply chain audit: build an SBOM, check license compliance, update third-party notices.
+- Verify lockfiles and reproducible builds; ensure deterministic outputs.
+- Check configuration and infrastructure drift across environments; maintain parity of flags and defaults.
+- Review access: tokens, keys, secret rotation, least-privilege policies.
+- Confirm ownership accuracy: `CODEOWNERS`, runbooks, on-call docs.
+- Ensure cross-repo consistency: PR/issue templates, commit message rules, branching model.

--- a/prompts/tasks/prompt-tasks-occasional-review.md
+++ b/prompts/tasks/prompt-tasks-occasional-review.md
@@ -1,0 +1,8 @@
+# Occasional Review Checklist
+
+Alongside the **Weekly Maintenance Checklist**, periodically conduct these tasks:
+
+- Update threat model and data-flow diagrams.
+- Run backup and restore drills if data is involved.
+- Expand benchmark suite and test datasets.
+- Check privacy and retention policy compliance.

--- a/prompts/tasks/prompt-tasks-release-checklist.md
+++ b/prompts/tasks/prompt-tasks-release-checklist.md
@@ -1,0 +1,9 @@
+# Release Preparation Checklist
+
+Run the **Weekly Maintenance Checklist**. Before each release, also:
+
+- Verify versioning and `CHANGELOG` updates; confirm semantic version bump.
+- Provide migration notes and deprecation warnings where needed.
+- Execute a clean-room build and run E2E and smoke tests on all target OS/architectures.
+- Perform packaging checks: signing, attach SBOM, ensure license headers.
+- Finalize release notes; regenerate and publish the docs site.

--- a/prompts/tasks/prompt-tasks-weekly-maintenance.md
+++ b/prompts/tasks/prompt-tasks-weekly-maintenance.md
@@ -1,0 +1,13 @@
+# Weekly Maintenance Checklist
+
+Use this checklist to keep the repository healthy on a weekly or bi-weekly cadence.
+
+- Review dependency update PRs (Renovate/Dependabot) and pin versions.
+- Run SCA/SAST and secret scans; triage and address findings.
+- Lint and format the entire repository; ensure `.editorconfig` and `.gitattributes` are respected.
+- Assess test health: flaky tests, coverage trends, and run a small mutation-testing sample.
+- Check CI health: job durations, cache hit rate, flaky jobs, missing matrix targets.
+- Triage `TODO`/`FIXME` tags and suppression comments.
+- Sweep documentation for freshness (`README`, `CONTRIBUTING`, setup steps); test new-machine install.
+- Link and spell check all docs; verify code snippets compile.
+- Look for automation opportunities (e.g., Renovate/Dependabot, CodeQL, secret scanners, link checkers, spell checkers).


### PR DESCRIPTION
## Summary
- add `tasks` category with weekly, monthly, release, occasional, and comprehensive checklists
- document new category in README
- note addition in changelog

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b875884a508324b864dd4c19c3d364