### PR TITLE
chore(prompts): align prompt library to Codex guide and add compliance report

### DIFF
--- a/docs/prompt-compliance-report.md
+++ b/docs/prompt-compliance-report.md
@@ -1,0 +1,39 @@
+# Prompt Compliance Report
+
+Date: 2025-09-03
+
+## Compliance Table
+| Prompt File | Clear & Specific | Context Provided | Instructional Tone | Acceptance Criteria | Focused Scope | Verification Guidance | Iteration Guidance | Repo Standards Awareness | Notes |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| prompts/agents/prompt-meta-prompt-generator.md | Pass | Pass | Pass | Pass | Pass | Pass | Pass | Pass | Already compliant |
+| prompts/agents/prompt-professional-ticket-reply.md | Pass | Pass | Pass | Pass | Pass | Pass | Pass | Pass | Added purpose, acceptance criteria, validation checklist |
+| prompts/agents/prompt-task-clarification-assistant.md | Pass | Pass | Pass | Pass | Pass | Pass | Pass | Pass | Added structure, acceptance criteria, validation |
+| prompts/agents/prompt-ticket-readiness-reviewer-for-codex.md | Pass | Pass | Pass | Pass | Pass | Pass | Pass | Pass | Added clarification step, acceptance criteria, validation |
+| prompts/tasks/prompt-tasks-comprehensive-maintenance.md | Pass | Pass | Pass | Pass | Pass | Pass | Pass | Pass | Added purpose, acceptance criteria, validation |
+| prompts/tasks/prompt-tasks-monthly-maintenance.md | Pass | Pass | Pass | Pass | Pass | Pass | Pass | Pass | Added structure and validation |
+| prompts/tasks/prompt-tasks-occasional-review.md | Pass | Pass | Pass | Pass | Pass | Pass | Pass | Pass | Added structure and validation |
+| prompts/tasks/prompt-tasks-release-checklist.md | Pass | Pass | Pass | Pass | Pass | Pass | Pass | Pass | Added structure and validation |
+| prompts/tasks/prompt-tasks-weekly-maintenance.md | Pass | Pass | Pass | Pass | Pass | Pass | Pass | Pass | Added structure and validation |
+| prompts/project-management/prompt-concept-functional-note.md | Pass | Pass | Pass | Pass | Pass | Pass | Pass | Pass | Already compliant |
+| prompts/project-management/prompt-epic-to-tasks.md | Pass | Pass | Pass | Pass | Pass | Pass | Pass | Pass | Added acceptance criteria and validation |
+| prompts/project-management/prompt-jira-ticket-assistant.md | Pass | Pass | Pass | Pass | Pass | Pass | Pass | Pass | Restructured for clarity and completeness |
+| prompts/project-management/prompt-repo-bootstrap.md | Pass | Pass | Pass | Pass | Pass | Pass | Pass | Pass | Already compliant |
+| prompts/project-management/prompt-rfc-feedback.md | Pass | Pass | Pass | Pass | Pass | Pass | Pass | Pass | Added acceptance criteria and validation |
+| prompts/project-management/prompt-update-docs.md | Pass | Pass | Pass | Pass | Pass | Pass | Pass | Pass | Added purpose, inputs, acceptance criteria |
+
+## Modified Prompt Summaries
+- **prompt-professional-ticket-reply.md**: Added license header, explicit purpose, inputs, steps, acceptance criteria, and validation checklist.
+- **prompt-task-clarification-assistant.md**: Introduced structured sections with acceptance criteria and validation checklist.
+- **prompt-ticket-readiness-reviewer-for-codex.md**: Added clarification step, acceptance criteria, and validation checklist.
+- **prompt-tasks-comprehensive-maintenance.md**: Rewrote as structured checklist with acceptance criteria and validation.
+- **prompt-tasks-monthly-maintenance.md**: Added purpose, prerequisite, and validation checklist.
+- **prompt-tasks-occasional-review.md**: Added purpose, prerequisite, and validation checklist.
+- **prompt-tasks-release-checklist.md**: Added purpose, prerequisite, acceptance criteria, and validation checklist.
+- **prompt-tasks-weekly-maintenance.md**: Added purpose, acceptance criteria, and validation checklist.
+- **prompt-epic-to-tasks.md**: Appended acceptance criteria and validation checklist.
+- **prompt-jira-ticket-assistant.md**: Replaced with structured prompt covering inputs, steps, output, acceptance criteria, and validation.
+- **prompt-rfc-feedback.md**: Added purpose, inputs, acceptance criteria, and validation checklist.
+- **prompt-update-docs.md**: Added license header, structured sections, and validation checklist.
+
+## Deprecated Prompts
+- None.

--- a/prompts/agents/prompt-professional-ticket-reply.md
+++ b/prompts/agents/prompt-professional-ticket-reply.md
@@ -1,30 +1,35 @@
+<!-- Licensed under CC-BY 4.0. -->
+
 # Professional Ticket Reply Assistant
 
-You are an AI assistant that drafts professional replies for Jira tickets, ticket comments, GitHub issues, emails, or other work-related discussion threads.
+## Purpose
+Draft professional replies for Jira tickets, comments, GitHub issues, emails, or other work-related threads while matching the original language.
 
-## Instructions
+## Inputs
+- Original message or thread content.
+- Optional tone preferences or company style guidance.
 
-1. **Language Matching**
-   - Always reply in the same language as the original message.
-   - If the provided input is only partial, confirm the language before drafting the final reply.
+## Steps
+1. Detect the language of the original message and reply in the same language.
+2. If context is incomplete, ask concise clarifying questions before drafting.
+3. Write a respectful, constructive reply that addresses questions and next steps.
+4. When the reply is long or nuanced, append a brief `Summary:` justification.
 
-2. **Tone & Value**
-   - Keep the tone professional, respectful, and constructive.
-   - Aim to add value by addressing questions, clarifying next steps, or summarizing key points.
+## Output
+- `Reply:` message ready to post.
+- Optional `Summary:` justification.
 
-3. **Clarification**
-   - If the user's input lacks context or is incomplete, ask concise clarifying questions before producing the final response.
+## Acceptance Criteria
+- Reply uses the same language as the source message.
+- Tone remains professional and respectful.
+- All user questions or concerns are addressed.
+- Summary provided when the reply is more than a few sentences.
 
-4. **Reply Generation**
-   - Produce a clear, ready-to-post reply snippet.
-   - Optionally append a short “Summary/Justification” section if the reply is long or nuanced.
-   - You may use external information when it improves clarity or completeness.
+## Notes
+- External information may be referenced when it improves clarity or completeness.
 
-5. **Format**
-   - Output should be structured as:
-     - `Reply:` \<the message to post\>
-     - Optional `Summary:` \<one- or two-sentence justification\>
-
-6. **Respect & Expectations**
-   - Ensure the reply meets user expectations and adheres to professional standards.
-
+## Validation Checklist
+- [ ] Reply language matches the original message.
+- [ ] All points from the user input are addressed.
+- [ ] Tone is professional and constructive.
+- [ ] Summary included when the reply is long.

--- a/prompts/agents/prompt-task-clarification-assistant.md
+++ b/prompts/agents/prompt-task-clarification-assistant.md
@@ -1,24 +1,31 @@
+<!-- Licensed under CC-BY 4.0. -->
+
 # Codex Task Clarification Assistant
 
-You are a task clarification assistant whose goal is to help a user craft a concise, unambiguous task description for Codex (an AI coding assistant). Follow these steps:
+## Purpose
+Help users craft a concise, unambiguous task description for Codex or similar coding assistants.
 
-1. Greet the user and ask for an initial description of the task they want Codex to perform.
-2. Engage in iterative clarification:
-   - Ask clarifying questions when details are missing or vague.
-   - Clarify the context in which the code should run, including programming languages, frameworks, dependencies, file names, and platform.
-   - Identify input data formats, output expectations, and any edge cases.
-   - Ask about acceptance criteria, required comments/tests, performance considerations, and any other constraints.
-   - Repeat back gathered details to confirm accuracy.
-3. Once the user confirms that all relevant details have been captured, produce a final “Codex Task” snippet that:
-   - Summarizes the problem in plain language.
-   - Specifies the exact requirements, constraints, and desired output.
-   - References the language, environment, and any key files.
-   - Is formatted clearly (e.g., as a short bullet list or numbered steps).
-4. Present the “Codex Task” snippet to the user and ask for final confirmation or edits.
-5. After confirmation, print the final snippet and conclude the conversation.
+## Steps
+1. Greet the user and request an initial description of the desired task.
+2. Iteratively ask clarifying questions about:
+   - Programming languages, frameworks, dependencies, and environment.
+   - Input formats, expected output, and edge cases.
+   - Acceptance criteria, required tests, comments, and performance constraints.
+3. Repeat back gathered details for confirmation.
+4. Once the user confirms completeness, produce a final **Codex Task** snippet summarizing the requirements, constraints, and desired output.
+5. Present the snippet to the user and ask for final confirmation or edits before ending.
 
-Guidelines:
-- Keep questions concise.
-- Avoid technical jargon unless the user uses it.
-- Iterate until the user agrees that the task is fully defined.
-- Do not produce the final task snippet until you believe the requirements are complete.
+## Output
+- Final **Codex Task** snippet ready to paste into Codex.
+
+## Acceptance Criteria
+- All relevant context and constraints captured and confirmed by the user.
+- Final snippet is concise, specific, and unambiguous.
+
+## Notes
+- Keep questions short and avoid jargon unless the user uses it.
+
+## Validation Checklist
+- [ ] Clarifying questions cover environment, inputs, outputs, and success criteria.
+- [ ] Summary repeated for user confirmation.
+- [ ] Final snippet generated only after confirmation.

--- a/prompts/agents/prompt-ticket-readiness-reviewer-for-codex.md
+++ b/prompts/agents/prompt-ticket-readiness-reviewer-for-codex.md
@@ -1,29 +1,40 @@
+<!-- Licensed under CC-BY 4.0. -->
+
 # Ticket Readiness Reviewer for Codex
 
-You are an assistant reviewing a software engineering ticket to determine if it is ready for implementation by Codex or a newly onboarded developer.
+## Purpose
+Evaluate whether a software engineering ticket contains enough information for implementation by Codex or a newly onboarded developer.
 
-The user will provide:
-
-- Ticket name (title)
+## Inputs
+- Ticket title
 - Ticket description
 
-Your task:
-Check the ticket against the following criteria and explain point by point whether the ticket satisfies each one, or if it is missing information:
+## Steps
+1. If essential information is missing, ask the user for clarification before proceeding.
+2. Check the ticket against these criteria and explain point by point whether each is clear or missing:
+   1. Clear Goal / Title
+   2. Context
+   3. Scope of Work
+   4. Constraints & Standards
+   5. Acceptance Criteria
+   6. Testing / Verification
+   7. Deliverables
+3. For each point respond with "✅ Clear / ❌ Missing / ⚠️ Partial" and a brief explanation.
+4. Summarize with "Ready for implementation" or "Needs refinement" and list any missing critical points.
 
-1. Clear Goal / Title – Does the ticket state a concise, unambiguous goal?
-2. Context – Does it explain why this task matters and where in the system it applies?
-3. Scope of Work – Is the scope clear and focused (one coherent unit of work)?
-4. Constraints & Standards – Are coding conventions, performance/security expectations, or references to repo standards included?
-5. Acceptance Criteria – Are "done" conditions explicitly defined (e.g., tests must pass, feature works as intended)?
-6. Testing / Verification – Does it specify how the outcome will be validated (unit tests, integration tests, linting, etc.)?
-7. Deliverables – Does it list expected outputs (code changes, updated docs, configs)?
+## Output
+- Point-by-point readiness evaluation.
+- Final summary judgment.
 
-For each point:
+## Acceptance Criteria
+- All seven criteria evaluated.
+- Clarifications requested when information is missing.
+- Final summary clearly states readiness status.
 
-- Answer "✅ Clear / ❌ Missing / ⚠️ Partial"
-- Provide a short explanation (1–2 sentences).
+## Notes
+- Reference repository standards such as `AGENTS.md` or `README.md` when the ticket mentions them.
 
-At the end, give a summary judgment:
-
-- "Ready for implementation" if all essentials are clear,
-- or "Needs refinement" with a list of missing critical points.
+## Validation Checklist
+- [ ] All criteria evaluated with status and explanation.
+- [ ] Missing information highlighted.
+- [ ] Final readiness summary included.

--- a/prompts/project-management/prompt-epic-to-tasks.md
+++ b/prompts/project-management/prompt-epic-to-tasks.md
@@ -94,3 +94,16 @@ If any of the following are missing, ask them one by one:
 2. Deadline or milestone date, if any.
 3. Systems/repos involved and any hard constraints.
 
+
+## Acceptance Criteria
+- All critical information gathered or explicit assumptions stated.
+- Task list covers each outcome with 0.5–2 day tasks including priority and time estimate.
+- Both Markdown table and JSON array are produced.
+- Assumptions and risks sections included.
+
+## Validation Checklist
+- [ ] Clarifying questions asked or assumptions listed.
+- [ ] Each outcome mapped to at least one task.
+- [ ] Tasks include priority and time estimate.
+- [ ] Markdown table and JSON array present.
+- [ ] Assumptions and risks sections provided.

--- a/prompts/project-management/prompt-jira-ticket-assistant.md
+++ b/prompts/project-management/prompt-jira-ticket-assistant.md
@@ -1,108 +1,57 @@
-prompt-jira-ticket-assistant.md
-• Intent: Help any teammate create a clear, testable Jira ticket that meets Definition of Ready and maps to a sensible issue type (Epic, Story, Task, Bug, Spike).
-• Audience: Backend/data teams, PM, QA.
-• Output language: English by default. Match the user’s language if explicitly requested.
-• Version: 1.0.0
-• Last updated: 2025-09-03
+<!-- Licensed under CC-BY 4.0. -->
 
-Grounded in the attached best-practices guide for backend teams, including DoR/DoD, traceability and type-specific templates for bugs and spikes.        
+# Jira Ticket Assistant
 
-⸻
+## Purpose
+Help backend and data teams draft clear, testable Jira tickets that meet the Definition of Ready and use the correct issue type (Epic, Story, Task, Bug, Spike).
 
-COPY-READY PROMPT (paste into ChatGPT)
+## Inputs
+Collect the following one at a time, asking only if missing or ambiguous:
+- Goal intent and any issue type hint.
+- Business value or problem statement.
+- Systems or components affected (services, jobs, datasets, tables, topics).
+- Scope and explicit non-goals.
+- Dependencies and external constraints.
+- Acceptance criteria in Given/When/Then format.
+- Test or validation approach and environments.
+- Estimate (story points or timebox for spikes).
+- Priority and severity (for bugs).
+- Related links, documents, or planned PRs.
+- Labels and components (keep labels few and consistent).
 
-You are a Jira Ticket Assistant for a backend/data engineering team (Scala, Spark/Databricks common). Produce one high-quality Jira ticket per run. Follow the rules exactly.
+## Steps
+1. Ask focused clarifying questions until the Definition of Ready is satisfied, then stop asking and draft the ticket.
+2. Apply issue-type rules:
+   - **Epic:** long-lived initiative with outcomes, deliverables, success metrics, stakeholders, milestones, risks, and Epic-level DoD.
+   - **Story:** user or system value slice with testable acceptance criteria.
+   - **Task:** technical work with clear output and tests.
+   - **Bug:** reproducible facts including environment, preconditions, repro steps, current vs expected behavior, impact, workaround, logs/IDs.
+   - **Spike:** research objective with background, approach, explicit timebox, expected output, and follow-up tickets.
+3. Follow writing standards:
+   - Summary: imperative verb + key object.
+   - Description structure: Background → Problem/Goal → Scope → Out of Scope → Technical notes → Dependencies/Links → Risks & Impact → Acceptance Criteria → Test Plan → Rollout/Monitoring/Rollback.
+   - Keep labels few and ensure traceability by linking related issues and planning to link commits/PRs with the issue key.
+4. Draft the ticket and return exactly the sections below:
+   - **Ticket Draft** block containing issue type, summary, description, fields & metadata (labels, components, priority, severity, estimate, versions, assignee, attachments), suggested subtasks, references.
+   - **DoR check** stating whether all required information is present.
+   - **DoD reminders** listing code merge, tests, docs, monitoring, stakeholder updates.
+   - **Anti-pattern warnings** highlighting vague summary, missing acceptance criteria, link-only description, epic used as label bucket, unlabeled ticket, unbounded spike, or unsupported assumptions.
+   - **Follow-ups** listing missing info to request or next tickets to create.
+5. If any key input is still missing, ask for it and wait; do not guess or output the draft early.
+6. Before returning the draft, ensure reproducibility for bugs, explicit timebox for spikes, and clear acceptance criteria for stories/tasks.
 
-Objectives
-1. Select the correct issue type from: Epic, Story, Task, Bug, Spike.
-2. Ask one clarifying question at a time until the Definition of Ready is satisfied. Then stop asking and produce the ticket.
-3. Return a single “Ticket Draft” block plus brief DoR/DoD checks, anti-pattern warnings, and suggested follow-ups.
+## Output
+- Ticket Draft block with the sections above.
+- DoR check, DoD reminders, anti-pattern warnings, and follow-ups.
 
-Inputs you must collect (ask only if missing or ambiguous)
-• Goal intent and issue type hint (if the user has one).
-• Business value or problem statement.
-• Systems/components affected (services, jobs, datasets, tables, topics).
-• Scope and explicit non-goals.
-• Dependencies and external constraints.
-• Acceptance criteria (Given/When/Then).
-• Test/validation approach and environments.
-• Estimate: story points or timebox (for spikes).
-• Priority vs severity (for bugs).
-• Links: related issues, documents, or PRs-to-be.
-• Labels and components. Keep labels few and consistent.
+## Acceptance Criteria
+- All mandatory inputs collected or clarified.
+- Ticket Draft includes required sections exactly once.
+- DoR check states Pass or needs info.
+- No unanswered questions remain unless listed under follow-ups.
 
-Issue-type rules
-• Epic: long-lived initiative with measurable outcomes. Deliverables list, success metrics, stakeholders, milestones, risks, Epic-level DoD.
-• Story: user or system value slice, estimable and testable, with acceptance criteria.
-• Task: technical work that delivers value but not framed as a user story. Clear output and tests.
-• Bug: must be reproducible or clearly described with facts, not opinions. Provide environment, preconditions, repro steps, current vs expected behavior, impact, workaround, logs/IDs.  
-• Spike: research to reduce uncertainty. Provide objective/question, background, approach, explicit timebox, expected output, resources. Spikes usually no story points; close on timebox with findings and follow-up tickets.  
-
-Writing standards
-• Summary: imperative verb + key object. Short and specific.
-• Description structure: Background → Problem/Goal → Scope → Out-of-Scope → Technical notes (services/jobs/tables, data shape, SLAs) → Dependencies/Links → Risks & Impact → Acceptance Criteria → Test Plan → Rollout/Monitoring/Rollback (if relevant).
-• Traceability: link related issues and plan to link commits/PRs via the issue key.  
-• Clarity: avoid vague phrases, Slack-only context, or “TBD”. Provide concrete inputs and outputs. A good ticket is understandable by any teammate later.  
-
-Output contract
-
-Return exactly the sections below, nothing else.
-
-Ticket Draft
-• Issue type: <Epic | Story | Task | Bug | Spike>
-• Summary: <concise, imperative>
-• Description:
-• Background
-• Problem/Goal
-• Scope
-• Out of scope
-• Technical notes (services/jobs/datasets; interfaces; config; migrations; perf targets)
-• Dependencies & links (issues, docs; plan to link PRs/commits using the key)
-• Risks & impact
-• Acceptance criteria (Gherkin bullets)
-• Given … When … Then …
-• Given … When … Then …
-• Test/validation (unit/integration/e2e, data samples, envs)
-• Rollout & monitoring (feature flags, dashboards, alerts; rollback plan if applicable)
-• Fields & metadata:
-• Labels: <lowercase, hyphenated, small set>
-• Components: <service/module names>
-• Priority: <e.g., High/Med/Low>
-• Severity (bugs): <Blocker/Critical/Major/Minor>
-• Estimate: 
-• Affected version / Fix version: 
-• Assignee/Owner: 
-• Attachments/Artifacts: <links to logs, data paths, screenshots>
-• Suggested subtasks:
-• <short, deliverable items>
-• References: 
-
-DoR check
-• Problem and scope are clear.
-• Acceptance criteria are testable.
-• Dependencies known.
-• Estimate provided.
-• Team can start without waiting on missing info. Status: <Pass|Needs info + what>.
-
-DoD reminders
-• Code merged with linked PR(s).
-• Tests added/updated to cover acceptance.
-• Docs updated (README/Runbook/Confluence).
-• Monitoring/alerts updated if needed.
-• Stakeholders updated. Status: .
-
-Anti-pattern warnings
-
-Flag if any: vague summary, missing acceptance criteria, “link-only” description, epic used as a label bucket, unlabeled ticket, unbounded spike, unsupported assumptions.  
-
-Follow-ups
-
-List missing info to request, or next tickets to create (e.g., implementation after spike).  
-
-Failure behavior
-
-If a key input is missing, ask one focused question and wait. Do not guess. Do not output the draft until DoR is met.
-
-Final quality pass
-
-Before returning the draft, ensure: reproducibility for bugs, explicit timebox for spikes, and clear acceptance criteria for stories/tasks. Link or plan to link code and PRs.      
+## Validation Checklist
+- [ ] Clarifying questions asked individually until DoR satisfied.
+- [ ] Ticket Draft contains issue type, summary, description, fields, subtasks, and references.
+- [ ] DoR check, DoD reminders, anti-pattern warnings, and follow-ups included.
+- [ ] Quality pass confirms reproducibility, timebox, and acceptance criteria.

--- a/prompts/project-management/prompt-rfc-feedback.md
+++ b/prompts/project-management/prompt-rfc-feedback.md
@@ -2,32 +2,35 @@
 
 # RFC Feedback Reviewer
 
-- **Intent:** Provide structured, constructive feedback on RFC documents.
-- **Audience:** Senior software engineers.
-- **Output language:** English by default.
-- **Version:** 1.0.0
-- **Last updated:** 2025-09-03
+## Purpose
+Provide structured, constructive feedback on Request for Comments (RFC) documents.
 
-## Role
-Act as a senior software engineer reviewing a Request for Comments (RFC) document. Provide constructive, actionable feedback that improves clarity, feasibility, and alignment with project goals.
+## Inputs
+- Full text of the RFC to review.
 
-## Instructions
-- Read the entire RFC.
-- For each issue or suggestion:
-  1. Quote the relevant RFC passage using a Markdown block quote.
-  2. Beneath the quote, write a single, standalone comment focused on that issue.
-- Keep comments concise, professional, and respectful.
-- Address topics such as missing context, ambiguous requirements, feasibility concerns, risks, or alternative approaches.
-- Avoid combining multiple issues in one comment.
+## Steps
+1. Read the entire RFC.
+2. For each notable issue or suggestion:
+   - Quote the relevant passage using a Markdown block quote.
+   - Beneath the quote, write a concise, standalone comment focused on that issue.
+3. Address missing context, ambiguity, feasibility concerns, risks, or alternative approaches.
+4. Continue until all significant issues are covered.
+5. If clarification is needed, ask the user before proceeding.
 
-## Output Format
-Return a series of separate comments, each formatted as:
-
+## Output
+A series of comments formatted as:
 ```
-> "Quoted passage from the RFC..."
+> "Quoted passage..."
 
 Comment explaining the concern, suggestion, or improvement.
 ```
 
-Continue until all notable issues are covered.
+## Acceptance Criteria
+- Each comment references a specific passage.
+- Feedback is professional, concise, and actionable.
+- All major concerns in the RFC are addressed.
 
+## Validation Checklist
+- [ ] Entire RFC reviewed.
+- [ ] Each comment includes a block quote and feedback.
+- [ ] Tone remains respectful and constructive.

--- a/prompts/project-management/prompt-update-docs.md
+++ b/prompts/project-management/prompt-update-docs.md
@@ -1,14 +1,30 @@
+<!-- Licensed under CC-BY 4.0. -->
+
 # Update Repository Documentation
 
-You are a documentation assistant. Ensure that important Markdown files reflect the repository's current state.
+## Purpose
+Ensure Markdown documentation reflects the repository's current state.
 
-## Instructions
-1. Review commit history since the last documentation update.
-2. Identify features, fixes, or structural changes needing documentation.
-3. Update existing Markdown files or create new ones (e.g., `README.md`, `CHANGELOG.md`, `CONTRIBUTING.md`).
-4. Keep tone and formatting consistent across files.
-5. Provide a concise summary of edits for the commit message.
+## Inputs
+- Commit history since the last documentation update.
+- Existing documentation files (`README.md`, `CHANGELOG.md`, `CONTRIBUTING.md`, etc.).
+
+## Steps
+1. Review recent commits for features, fixes, or structural changes needing documentation.
+2. Update existing Markdown files or create new ones to cover those changes.
+3. Maintain consistent tone and formatting across files.
+4. Prepare a concise summary of edits for the commit message.
 
 ## Output
 - Updated Markdown files saved in the repository.
 - Short summary of documentation changes for the commit message.
+
+## Acceptance Criteria
+- Documentation reflects recent repository changes.
+- Formatting and tone remain consistent.
+- Summary clearly states key updates.
+
+## Validation Checklist
+- [ ] Commit history reviewed for documentation needs.
+- [ ] All affected docs updated or created.
+- [ ] Summary prepared for commit message.

--- a/prompts/tasks/prompt-tasks-comprehensive-maintenance.md
+++ b/prompts/tasks/prompt-tasks-comprehensive-maintenance.md
@@ -1,40 +1,56 @@
+<!-- Licensed under CC-BY 4.0. -->
+
 # Comprehensive Maintenance Checklist
 
-Use this prompt when performing a full maintenance sweep. It combines weekly, monthly, release, and occasional tasks.
+## Purpose
+Perform a full maintenance sweep combining weekly, monthly, release, and occasional tasks.
 
-## Weekly Tasks
-- Review dependency update PRs (Renovate/Dependabot) and pin versions.
+## Steps
+### Weekly Tasks
+- Review dependency update PRs and pin versions.
 - Run SCA/SAST and secret scans; triage and address findings.
-- Lint and format the entire repository; ensure `.editorconfig` and `.gitattributes` are respected.
-- Assess test health: flaky tests, coverage trends, and run a small mutation-testing sample.
+- Lint and format the repository; ensure `.editorconfig` and `.gitattributes` are respected.
+- Assess test health: flaky tests, coverage trends, and a small mutation-testing sample.
 - Check CI health: job durations, cache hit rate, flaky jobs, missing matrix targets.
 - Triage `TODO`/`FIXME` tags and suppression comments.
-- Sweep documentation for freshness (`README`, `CONTRIBUTING`, setup steps); test new-machine install.
-- Link and spell check all docs; verify code snippets compile.
+- Sweep documentation for freshness; test new-machine install.
+- Link and spell check docs; verify code snippets compile.
 
-## Monthly Tasks
-- Architecture review; update ADRs and diagrams; examine the dependency graph for tangles.
+### Monthly Tasks
+- Architecture review; update ADRs and diagrams; examine dependency graph for tangles.
 - Remove dead code and unused modules; plan deprecations; audit public API surface.
 - Capture performance baselines and detect regressions on key paths.
 - Perform a supply chain audit: build an SBOM, check license compliance, update third-party notices.
-- Verify lockfiles and reproducible builds; ensure deterministic outputs.
-- Check configuration and infrastructure drift across environments; maintain parity of flags and defaults.
+- Verify lockfiles and reproducible builds.
+- Check configuration and infrastructure drift across environments.
 - Review access: tokens, keys, secret rotation, least-privilege policies.
 - Confirm ownership accuracy: `CODEOWNERS`, runbooks, on-call docs.
-- Ensure cross-repo consistency: PR/issue templates, commit message rules, branching model.
+- Ensure cross-repo consistency: templates, commit rules, branching model.
 
-## Release Tasks
+### Release Tasks
 - Verify versioning and `CHANGELOG` updates; confirm semantic version bump.
 - Provide migration notes and deprecation warnings where needed.
 - Execute a clean-room build and run E2E and smoke tests on all target OS/architectures.
 - Perform packaging checks: signing, attach SBOM, ensure license headers.
 - Finalize release notes; regenerate and publish the docs site.
 
-## Occasional Tasks
+### Occasional Tasks
 - Update threat model and data-flow diagrams.
 - Run backup and restore drills if data is involved.
 - Expand benchmark suite and test datasets.
 - Check privacy and retention policy compliance.
 
-## Automation
-- Leverage tools like Renovate/Dependabot, CodeQL or equivalent, secret scanners, link and spell checkers, doc snippet compilers, flaky-test detectors, coverage gating, and release CI with changelog generation wherever possible.
+## Output
+- Confirmation that each checklist item was reviewed and addressed.
+- Notes for follow-up actions.
+
+## Acceptance Criteria
+- All tasks reviewed and actions noted.
+- Tests, linters, and scans run where applicable.
+- Documentation and configuration remain current.
+
+## Validation Checklist
+- [ ] Dependency updates and security scans completed.
+- [ ] Documentation, configurations, and ownership verified.
+- [ ] Release and occasional tasks checked as needed.
+- [ ] Follow-up issues logged for any gaps.

--- a/prompts/tasks/prompt-tasks-monthly-maintenance.md
+++ b/prompts/tasks/prompt-tasks-monthly-maintenance.md
@@ -1,7 +1,14 @@
+<!-- Licensed under CC-BY 4.0. -->
+
 # Monthly Maintenance Checklist
 
-First complete the **Weekly Maintenance Checklist**. In addition, perform these monthly or quarterly tasks:
+## Purpose
+Supplement weekly maintenance with monthly or quarterly tasks.
 
+## Prerequisite
+Complete the **Weekly Maintenance Checklist** first.
+
+## Steps
 - Architecture review; update ADRs and diagrams; examine the dependency graph for tangles.
 - Remove dead code and unused modules; plan deprecations; audit public API surface.
 - Capture performance baselines and detect regressions on key paths.
@@ -11,3 +18,17 @@ First complete the **Weekly Maintenance Checklist**. In addition, perform these 
 - Review access: tokens, keys, secret rotation, least-privilege policies.
 - Confirm ownership accuracy: `CODEOWNERS`, runbooks, on-call docs.
 - Ensure cross-repo consistency: PR/issue templates, commit message rules, branching model.
+
+## Output
+- Notes on each task performed and any follow-up actions.
+
+## Acceptance Criteria
+- Every listed task reviewed and addressed.
+- Findings and follow-ups documented.
+
+## Validation Checklist
+- [ ] Architecture and dependency graph reviewed.
+- [ ] Dead code removed or deprecations planned.
+- [ ] Supply chain and license checks completed.
+- [ ] Configuration, access, and ownership verified.
+- [ ] Cross-repo templates and rules aligned.

--- a/prompts/tasks/prompt-tasks-occasional-review.md
+++ b/prompts/tasks/prompt-tasks-occasional-review.md
@@ -1,8 +1,28 @@
+<!-- Licensed under CC-BY 4.0. -->
+
 # Occasional Review Checklist
 
-Alongside the **Weekly Maintenance Checklist**, periodically conduct these tasks:
+## Purpose
+Conduct periodic tasks that complement the Weekly Maintenance Checklist.
 
+## Prerequisite
+Complete the **Weekly Maintenance Checklist** alongside these tasks.
+
+## Steps
 - Update threat model and data-flow diagrams.
 - Run backup and restore drills if data is involved.
 - Expand benchmark suite and test datasets.
 - Check privacy and retention policy compliance.
+
+## Output
+- Notes on each occasional task and any required follow-ups.
+
+## Acceptance Criteria
+- Each task reviewed at appropriate intervals.
+- Findings documented and follow-ups scheduled.
+
+## Validation Checklist
+- [ ] Threat model and diagrams refreshed.
+- [ ] Backup and restore procedures tested.
+- [ ] Benchmarks and datasets expanded.
+- [ ] Privacy and retention compliance verified.

--- a/prompts/tasks/prompt-tasks-release-checklist.md
+++ b/prompts/tasks/prompt-tasks-release-checklist.md
@@ -1,9 +1,32 @@
+<!-- Licensed under CC-BY 4.0. -->
+
 # Release Preparation Checklist
 
-Run the **Weekly Maintenance Checklist**. Before each release, also:
+## Purpose
+Ensure the repository is ready for a production release.
 
+## Prerequisite
+Run the **Weekly Maintenance Checklist** before starting these tasks.
+
+## Steps
 - Verify versioning and `CHANGELOG` updates; confirm semantic version bump.
 - Provide migration notes and deprecation warnings where needed.
 - Execute a clean-room build and run E2E and smoke tests on all target OS/architectures.
 - Perform packaging checks: signing, attach SBOM, ensure license headers.
 - Finalize release notes; regenerate and publish the docs site.
+
+## Output
+- Confirmation that release tasks are complete.
+- Notes on any remaining issues.
+
+## Acceptance Criteria
+- Version and changelog accurately reflect changes.
+- Clean-room build and tests succeed on all targets.
+- Packaging and documentation steps completed.
+
+## Validation Checklist
+- [ ] Version and `CHANGELOG` updated.
+- [ ] Migration notes and deprecation warnings provided.
+- [ ] Build and tests run on all targets.
+- [ ] Packaging, signing, and SBOM steps completed.
+- [ ] Release notes finalized and docs published.

--- a/prompts/tasks/prompt-tasks-weekly-maintenance.md
+++ b/prompts/tasks/prompt-tasks-weekly-maintenance.md
@@ -1,7 +1,11 @@
+<!-- Licensed under CC-BY 4.0. -->
+
 # Weekly Maintenance Checklist
 
-Use this checklist to keep the repository healthy on a weekly or bi-weekly cadence.
+## Purpose
+Keep the repository healthy on a weekly or bi-weekly cadence.
 
+## Steps
 - Review dependency update PRs (Renovate/Dependabot) and pin versions.
 - Run SCA/SAST and secret scans; triage and address findings.
 - Lint and format the entire repository; ensure `.editorconfig` and `.gitattributes` are respected.
@@ -11,3 +15,17 @@ Use this checklist to keep the repository healthy on a weekly or bi-weekly caden
 - Sweep documentation for freshness (`README`, `CONTRIBUTING`, setup steps); test new-machine install.
 - Link and spell check all docs; verify code snippets compile.
 - Look for automation opportunities (e.g., Renovate/Dependabot, CodeQL, secret scanners, link checkers, spell checkers).
+
+## Output
+- Notes on actions taken and any follow-up items.
+
+## Acceptance Criteria
+- Each task reviewed and addressed.
+- Tests, scans, and linters run where applicable.
+- Follow-up tasks documented.
+
+## Validation Checklist
+- [ ] Dependency updates reviewed.
+- [ ] Security scans and linters executed.
+- [ ] Documentation refreshed and checked.
+- [ ] Automation opportunities logged.


### PR DESCRIPTION
## Summary
- rewrite prompt files with explicit purpose, inputs, outputs, acceptance criteria and validation guidance
- add Codex prompt compliance report covering all prompt templates

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b87abe6e808324b3d558df31fa04d1