### PR TITLE
chore(docs): add manual prompt catalog with per-category indexes and contributor/agent maintenance rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,16 @@ The agent may take on the following roles:
 4. Write short explanatory headers inside each prompt when needed.  
 5. Ensure no duplication across categories.
 
+## When an agent creates or edits prompts
+
+- After writing to prompts/, update:
+  - prompts/README.md
+  - the matching category README.md
+- Ensure Title, Goal, and Path follow the catalog rules.
+- Keep alphabetical order by Title.
+- Include catalog updates in the same commit as the prompt changes.
+- If the agent cannot determine a clear Goal from the prompt body, write a temporary one-liner and open a follow-up task for the author to refine it.
+
 ## Example Task Workflow
 
 1. User requests a new prompt for data analysis.  

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,3 +10,28 @@ Thank you for contributing to **jonv11-prompts-library**. To keep the library co
 - Update documentation when adding new prompts or folders.
 - All contributions are released under the CC-BY 4.0 license.
 - Refer to [AGENTS.md](AGENTS.md) for project roles and conventions.
+
+## Prompt files and catalog maintenance (manual)
+
+When you add, rename, or remove any file under prompts/, you must update:
+
+- prompts/README.md
+- the relevant per-category README.md (e.g., prompts/agents/README.md)
+
+How to add an entry:
+
+1. Open the prompt file and copy the first H1 as Title. If none, derive from filename (kebab to Title Case).
+2. Take the first descriptive sentence under the H1 as Goal. If none, write a concise goal ≤ 140 chars focused on the outcome.
+3. Use a relative link Path (e.g., prompts/agents/prompt-…md).
+4. Insert a row into the correct category table. Keep rows sorted alphabetically by Title.
+
+How to rename or move:
+
+- Update the Path in both catalogs and keep alphabetical order.
+
+How to remove:
+
+- Delete the row in both catalogs.
+
+Do this in the same commit as the prompt change.
+Validate manually by clicking links in GitHub’s file view before merging.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 A structured library of reusable AI prompts for ChatGPT, Copilot, and other LLM-based agents.  
 The goal is to keep prompts organized, portable, and ready to use across coding, documentation, data analysis, creative tasks, and project management.
 
+## Prompt catalog
+
+- Browse all prompts: [prompts/README.md](prompts/README.md)
+
 ## Structure
 
 ```

--- a/prompts/README.md
+++ b/prompts/README.md
@@ -1,0 +1,39 @@
+# Prompt Catalog
+
+Canonical index of prompts. Per-category indexes live in subfolders.
+
+## Agents
+
+| Title | Goal | Path |
+| --- | --- | --- |
+| [Codex Task Clarification Assistant](agents/prompt-task-clarification-assistant.md) | Help users craft a concise, unambiguous task description for Codex or similar coding assistants. | agents/prompt-task-clarification-assistant.md |
+| [Convention Harvesting and Documentation Assistant](agents/prompt-convention-harvesting-and-documentation-assistant.md) | Elicit, research, and document explicit conventions for a project or topic. | agents/prompt-convention-harvesting-and-documentation-assistant.md |
+| [Professional Ticket Reply Assistant](agents/prompt-professional-ticket-reply.md) | Draft professional replies to tickets, comments, issues, or emails while matching the original language. | agents/prompt-professional-ticket-reply.md |
+| [Prompt Creation Meta-Assistant](agents/prompt-meta-prompt-generator.md) | Helps contributors add new prompts to the jonv11-prompts-library. | agents/prompt-meta-prompt-generator.md |
+| [Ticket Readiness Reviewer for Codex](agents/prompt-ticket-readiness-reviewer-for-codex.md) | Evaluate whether a software engineering ticket contains enough information for implementation by Codex or a newly onboarded developer. | agents/prompt-ticket-readiness-reviewer-for-codex.md |
+
+## Project Management
+
+| Title | Goal | Path |
+| --- | --- | --- |
+| [Concept Functional Note Assistant](project-management/prompt-concept-functional-note.md) | Guide a user through defining a concept and produce a functional note with a complete, professional description. | project-management/prompt-concept-functional-note.md |
+| [Epic to Tasks Prompt](project-management/prompt-epic-to-tasks.md) | Assistant that decomposes a single epic ticket into granular, implementable tasks. | project-management/prompt-epic-to-tasks.md |
+| [Jira Ticket Assistant](project-management/prompt-jira-ticket-assistant.md) | Help backend and data teams draft clear, testable Jira tickets that meet Definition of Ready and use the correct issue type. | project-management/prompt-jira-ticket-assistant.md |
+| [Repository Bootstrap Prompt](project-management/prompt-repo-bootstrap.md) | Guide a user through bootstrapping a new GitHub repository using widely accepted standards. | project-management/prompt-repo-bootstrap.md |
+| [RFC Feedback Reviewer](project-management/prompt-rfc-feedback.md) | Provide structured, constructive feedback on Request for Comments (RFC) documents. | project-management/prompt-rfc-feedback.md |
+| [Update Repository Documentation](project-management/prompt-update-docs.md) | Ensure Markdown documentation reflects the repository's current state. | project-management/prompt-update-docs.md |
+
+## Tasks
+
+| Title | Goal | Path |
+| --- | --- | --- |
+| [Comprehensive Maintenance Checklist](tasks/prompt-tasks-comprehensive-maintenance.md) | Perform a full maintenance sweep combining weekly, monthly, release, and occasional tasks. | tasks/prompt-tasks-comprehensive-maintenance.md |
+| [Monthly Maintenance Checklist](tasks/prompt-tasks-monthly-maintenance.md) | Supplement weekly maintenance with monthly or quarterly tasks. | tasks/prompt-tasks-monthly-maintenance.md |
+| [Occasional Review Checklist](tasks/prompt-tasks-occasional-review.md) | Conduct periodic tasks that complement the Weekly Maintenance Checklist. | tasks/prompt-tasks-occasional-review.md |
+| [Release Preparation Checklist](tasks/prompt-tasks-release-checklist.md) | Ensure the repository is ready for a production release. | tasks/prompt-tasks-release-checklist.md |
+| [Repository Audit and BACKLOG.md Synthesis](tasks/prompt-tasks-repo-audit-backlog.md) | Analyze the repository end to end and create or update a root-level BACKLOG.md with concise, non-duplicated, actionable items. | tasks/prompt-tasks-repo-audit-backlog.md |
+| [Weekly Maintenance Checklist](tasks/prompt-tasks-weekly-maintenance.md) | Keep the repository healthy on a weekly or bi-weekly cadence. | tasks/prompt-tasks-weekly-maintenance.md |
+
+### Conventions
+
+Alphabetical by title, goals ≤ 140 chars, links are relative.

--- a/prompts/agents/README.md
+++ b/prompts/agents/README.md
@@ -1,0 +1,13 @@
+# Agents Prompts
+
+Prompts defining AI agent roles, behaviors, and workflows.
+
+| Title | Goal | Path |
+| --- | --- | --- |
+| [Codex Task Clarification Assistant](prompt-task-clarification-assistant.md) | Help users craft a concise, unambiguous task description for Codex or similar coding assistants. | prompt-task-clarification-assistant.md |
+| [Convention Harvesting and Documentation Assistant](prompt-convention-harvesting-and-documentation-assistant.md) | Elicit, research, and document explicit conventions for a project or topic. | prompt-convention-harvesting-and-documentation-assistant.md |
+| [Professional Ticket Reply Assistant](prompt-professional-ticket-reply.md) | Draft professional replies to tickets, comments, issues, or emails while matching the original language. | prompt-professional-ticket-reply.md |
+| [Prompt Creation Meta-Assistant](prompt-meta-prompt-generator.md) | Helps contributors add new prompts to the jonv11-prompts-library. | prompt-meta-prompt-generator.md |
+| [Ticket Readiness Reviewer for Codex](prompt-ticket-readiness-reviewer-for-codex.md) | Evaluate whether a software engineering ticket contains enough information for implementation by Codex or a newly onboarded developer. | prompt-ticket-readiness-reviewer-for-codex.md |
+
+[Back to main catalog](../README.md)

--- a/prompts/project-management/README.md
+++ b/prompts/project-management/README.md
@@ -1,0 +1,14 @@
+# Project Management Prompts
+
+Prompts for planning, ticketing, and documentation workflows.
+
+| Title | Goal | Path |
+| --- | --- | --- |
+| [Concept Functional Note Assistant](prompt-concept-functional-note.md) | Guide a user through defining a concept and produce a functional note with a complete, professional description. | prompt-concept-functional-note.md |
+| [Epic to Tasks Prompt](prompt-epic-to-tasks.md) | Assistant that decomposes a single epic ticket into granular, implementable tasks. | prompt-epic-to-tasks.md |
+| [Jira Ticket Assistant](prompt-jira-ticket-assistant.md) | Help backend and data teams draft clear, testable Jira tickets that meet Definition of Ready and use the correct issue type. | prompt-jira-ticket-assistant.md |
+| [Repository Bootstrap Prompt](prompt-repo-bootstrap.md) | Guide a user through bootstrapping a new GitHub repository using widely accepted standards. | prompt-repo-bootstrap.md |
+| [RFC Feedback Reviewer](prompt-rfc-feedback.md) | Provide structured, constructive feedback on Request for Comments (RFC) documents. | prompt-rfc-feedback.md |
+| [Update Repository Documentation](prompt-update-docs.md) | Ensure Markdown documentation reflects the repository's current state. | prompt-update-docs.md |
+
+[Back to main catalog](../README.md)

--- a/prompts/tasks/README.md
+++ b/prompts/tasks/README.md
@@ -1,0 +1,14 @@
+# Tasks Prompts
+
+Prompts for recurring maintenance and release checklists.
+
+| Title | Goal | Path |
+| --- | --- | --- |
+| [Comprehensive Maintenance Checklist](prompt-tasks-comprehensive-maintenance.md) | Perform a full maintenance sweep combining weekly, monthly, release, and occasional tasks. | prompt-tasks-comprehensive-maintenance.md |
+| [Monthly Maintenance Checklist](prompt-tasks-monthly-maintenance.md) | Supplement weekly maintenance with monthly or quarterly tasks. | prompt-tasks-monthly-maintenance.md |
+| [Occasional Review Checklist](prompt-tasks-occasional-review.md) | Conduct periodic tasks that complement the Weekly Maintenance Checklist. | prompt-tasks-occasional-review.md |
+| [Release Preparation Checklist](prompt-tasks-release-checklist.md) | Ensure the repository is ready for a production release. | prompt-tasks-release-checklist.md |
+| [Repository Audit and BACKLOG.md Synthesis](prompt-tasks-repo-audit-backlog.md) | Analyze the repository end to end and create or update a root-level BACKLOG.md with concise, non-duplicated, actionable items. | prompt-tasks-repo-audit-backlog.md |
+| [Weekly Maintenance Checklist](prompt-tasks-weekly-maintenance.md) | Keep the repository healthy on a weekly or bi-weekly cadence. | prompt-tasks-weekly-maintenance.md |
+
+[Back to main catalog](../README.md)


### PR DESCRIPTION
## Summary
- add canonical prompt catalog with per-category indexes for agents, project management, and tasks
- link catalog from root README
- document manual catalog maintenance workflow for contributors and agents

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba30aa8d3c8324b4c438b8b6690f15