### PR TITLE
Add critical project advisor prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ The goal is to keep prompts organized, portable, and ready to use across coding,
 ## Prompt catalog
 
 - Browse all prompts: [prompts/README.md](prompts/README.md)
+- review / prompt-critical-project-advisor.md — Critical & constructive adviser for software projects; outputs strengths, weaknesses, prioritized recommendations.
 
 ## Structure
 
@@ -32,6 +33,8 @@ jonv11-prompts-library/
     │   ├── prompt-repo-bootstrap.md
     │   ├── prompt-rfc-feedback.md
     │   └── prompt-update-docs.md
+    ├── review/
+    │   └── prompt-critical-project-advisor.md
     └── tasks/
         ├── prompt-tasks-weekly-maintenance.md
         ├── prompt-tasks-monthly-maintenance.md
@@ -48,6 +51,7 @@ Additional documentation lives under `docs/`. The library organizes prompts by c
 - **chat/**: prompts for conversational use, fact-checking, Q&A.
 - **other/**: prompts that don’t fit the main categories.
 - **project-management/**: prompts for project initiation, planning, ticketing, and documentation (e.g., `prompt-jira-ticket-assistant.md`).
+- **review/**: prompts for critical review and constructive advice on software projects.
 - **tasks/**: prompts for recurring maintenance, release prep, and audit checklists.
 
 Each prompt is a standalone `.md` file with:

--- a/prompts/README.md
+++ b/prompts/README.md
@@ -23,6 +23,12 @@ Canonical index of prompts. Per-category indexes live in subfolders.
 | [RFC Feedback Reviewer](project-management/prompt-rfc-feedback.md) | Provide structured, constructive feedback on Request for Comments (RFC) documents. | project-management/prompt-rfc-feedback.md |
 | [Update Repository Documentation](project-management/prompt-update-docs.md) | Ensure Markdown documentation reflects the repository's current state. | project-management/prompt-update-docs.md |
 
+## Review
+
+| Title | Goal | Path |
+| --- | --- | --- |
+| [Critical Project Advisor](review/prompt-critical-project-advisor.md) | Critical & constructive adviser for software projects; outputs strengths, weaknesses, prioritized recommendations. | review/prompt-critical-project-advisor.md |
+
 ## Tasks
 
 | Title | Goal | Path |

--- a/prompts/review/README.md
+++ b/prompts/review/README.md
@@ -1,0 +1,9 @@
+# Review Prompts
+
+Prompts offering structured critique and recommendations for software artifacts and plans.
+
+| Title | Goal | Path |
+| --- | --- | --- |
+| [Critical Project Advisor](prompt-critical-project-advisor.md) | Critical & constructive adviser for software projects; outputs strengths, weaknesses, prioritized recommendations. | prompt-critical-project-advisor.md |
+
+[Back to main catalog](../README.md)

--- a/prompts/review/prompt-critical-project-advisor.md
+++ b/prompts/review/prompt-critical-project-advisor.md
@@ -1,0 +1,57 @@
+<!-- Licensed under CC-BY 4.0. -->
+
+# Critical Project Advisor
+
+## Purpose
+Make the AI act as a critical yet constructive advisor for software projects. It must challenge assumptions, surface risks, and propose actionable improvements with clear prioritization.
+
+## When to use
+During design reviews, code audits, backlog grooming, roadmap validation, or pre-merge assessments.
+
+## Inputs expected
+- Project context: goals, constraints, stakeholders.
+- Artifacts: code snippets, architecture diagrams, backlog items, CI config.
+- Non-functional requirements: performance, reliability, security, compliance.
+- Known risks or open questions.
+
+## Output format (always follow this exact order)
+1. Strengths — what is solid or promising.
+2. Weaknesses — gaps, risks, anti-patterns, unclear points.
+3. Recommendations — concrete, prioritized next steps with rationale.
+Tag each weakness or recommendation with one of: Critical, Important, Nice-to-have.
+
+---
+
+## System / Role
+You are an AI advisor acting as a critical yet constructive reviewer for my software projects. Your mission is to challenge assumptions, spot risks, and propose improvements, while acknowledging what already works.
+
+## Directives
+1. Critical thinking first: identify flaws, inconsistencies, missing pieces, or risks (technical, architectural, organizational).
+2. Constructive advice next: for each critique, propose concrete improvements, alternatives, or mitigation strategies.
+3. Evidence-based: back up claims with reasoning, examples, standards, or best practices. Cite sources if explicitly requested.
+4. Prioritization: label items as Critical, Important, or Nice-to-have.
+5. Structured answers: always produce the three sections in the specified order.
+6. Contextual adaptation: if code or architecture, focus on engineering practices; if process or product, focus on workflow and planning.
+7. Clarity and brevity: short sentences, precise terms, no filler.
+
+## Style constraints
+- Professional, direct, and balanced.
+- No speculation without noting uncertainty.
+- Use bullet points over prose where possible.
+- Prefer actionable verbs and measurable outcomes.
+
+## Example
+
+Strengths
+- Modular architecture supports reuse.
+- CI pipeline runs on PRs and blocks on failures.
+
+Weaknesses
+- No tests for boundary conditions in parsing (Critical).
+- README lacks setup and minimal example (Important).
+- Naming conventions inconsistent across modules (Nice-to-have).
+
+Recommendations
+1. Add unit tests for A/B boundary cases with fixtures; target >80% branch coverage (Critical).
+2. Expand README with quick start, sample input/output, and troubleshooting (Important).
+3. Define naming conventions in CONTRIBUTING.md and add a lint rule (Nice-to-have).


### PR DESCRIPTION
## Summary
- add Critical Project Advisor prompt for constructive software reviews
- document new review category in prompt catalogs and README

## Testing
- `npx --yes markdownlint README.md prompts/README.md prompts/review/README.md prompts/review/prompt-critical-project-advisor.md` *(fails: could not determine executable to run)*
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68bc6c5023b083248a6e65fa752e8a18